### PR TITLE
Update Java

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@
 *.pyc
 *__pycache__
 
+*.class
 
 

--- a/april/java/.gitignore
+++ b/april/java/.gitignore
@@ -1,3 +1,6 @@
 java.hprof.txt
 hs_err_*.log
 docs
+
+build/
+jni/include/

--- a/april/java/build.xml
+++ b/april/java/build.xml
@@ -23,7 +23,7 @@
              defaultexcludes="yes"
              destdir="docs/api"
              Public="yes"
-             source="1.6"
+             source="11"
 	     />
   </target>
 
@@ -78,8 +78,9 @@
        destdir="build"
        compiler="extJavac"
        deprecation="yes"
-       source="1.6"
-       target="1.6"
+       source="11"
+       target="11"
+       nativeheaderdir="${basedir}/jni/include"
        >
     </javac>
   </target>

--- a/april/java/jni/common.mk
+++ b/april/java/jni/common.mk
@@ -12,6 +12,8 @@ SHARED_EXT = so
 
 # parse last line of update-alternatives --display to find out where the currently selected jvm lives, then make include path
 JNI_INCLUDES = -I$(shell readlink -f `which javac` | sed "s:/bin/javac:/include:")
+# Ubuntu JNI headers are also under /linux
+JNI_INCLUDES := $(JNI_INCLUDES) $(JNI_INCLUDES)/linux
 endif
 
 #############################################################
@@ -25,5 +27,10 @@ LDFLAGS = -dynamiclib -framework OpenGL -framework JavaVM -L/usr/X11/lib
 SHARED_EXT = jnilib
 
 JNI_INCLUDES = -I/System/Library/Frameworks/JavaVM.framework/Headers/ -I/usr/X11/include/
+JNI_INCLUDES := $(JNI_INCLUDES) $(JNI_INCLUDES)/linux
 
 endif
+
+# Add our generated header files to the JNI includes; .. will be this jni directory from the 
+# point of view of the makefiles that use this one. I hate Makefiles.
+JNI_INCLUDES := $(JNI_INCLUDES) -I${CURDIR}/../include

--- a/april/java/jni/jcam/Makefile
+++ b/april/java/jni/jcam/Makefile
@@ -36,12 +36,8 @@ $(DESTLIB): $(LIB)
 	@echo "    [$@]"
 	cp $(LIB) $(DESTLIB)
 
-libimagesource.so: april_jcam_ImageSourceNative.h $(LIBIMAGESOURCE_OBJS)
+libimagesource.so: $(LIBIMAGESOURCE_OBJS)
 	$(LD) $(LDFLAGS) $(LIBIMAGESOURCE_OBJS) -o libimagesource.so -ldc1394 -lc -lcommon -lpng
-
-april_jcam_ImageSourceNative.h:
-	echo "Rebuilding JNI headers. Ensure java file has been recently built."
-	javah -classpath ../../april.jar  april.jcam.ImageSourceNative
 
 clean:
 	rm -f *~ april_jcam_ImageSourceNative.h april_jcam_ImageSourceFormat.h $(LIB) $(DESTLIB) $(LIBIMAGESOURCE_OBJS) istest main.o tcpstream tcp_image_streamer.o

--- a/april/java/jni/jgl/Makefile
+++ b/april/java/jni/jgl/Makefile
@@ -11,16 +11,12 @@ $(DESTLIB) : $(LIB)
 	cp $(LIB) $(DESTLIB)
 
 LIBJGL_OBJS += glcontext.o glcontext-x11.o gl_jni.o lphash.o parray.o
-$(LIB): april_vis_GL.h $(LIBJGL_OBJS)
+$(LIB): $(LIBJGL_OBJS)
 	$(LD) $(LDFLAGS) $(LIBJGL_OBJS) -o $@ -lGL -lX11
 
 #############################################################
 %.o: %.c
 	$(CC) $(CCFLAGS) $(JNI_INCLUDES) $<
-
-april_vis_GL.h: ../../src/april/vis/GL.java
-	@echo "NOTICE: Rebuilding JNI headers. Ensure java file has been recently built."
-	javah -classpath ../../april.jar  april.vis.GL
 
 clean:
 	rm -rf $(LIBJGL_OBJS) *~ april_vis_GL.h $(LIB) $(DESTLIB)

--- a/april/java/jni/jserial/Makefile
+++ b/april/java/jni/jserial/Makefile
@@ -26,15 +26,11 @@ $(DESTLIB): $(LIB)
 	@echo "    [$@]"
 	cp $(LIB) $(DESTLIB)
 
-libjserial.so: april_jserial_JSerial.h $(LIB_APRIL_JSERIAL_OBJS)
+libjserial.so: $(LIB_APRIL_JSERIAL_OBJS)
 	$(LD) $(LDFLAGS) --shared $(LIB_APRIL_JSERIAL_OBJS) -o libjserial.so
 
-april_jserial_JSerial.h:
-	echo "Rebuilding JNI headers. Ensure java file has been recently built."
-	javah -classpath ../../april.jar  april.jserial.JSerial
-
 clean:
-	rm -f $(LIB_APRIL_JSERIAL_OBJS) *~ april_jserial_JSerial.h *.so $(LIB) $(DESTLIB)
+	rm -f $(LIB_APRIL_JSERIAL_OBJS) *~ *.so $(LIB) $(DESTLIB)
 
 %.o: %.c
 	$(CC) $(CCFLAGS) $(JNI_INCLUDES) $<

--- a/java/build.xml
+++ b/java/build.xml
@@ -23,7 +23,7 @@
              defaultexcludes="yes"
              destdir="docs/api"
              Public="yes"
-             source="1.6"
+             source="11"
 	     />
   </target>
 
@@ -64,8 +64,8 @@
        destdir="build"
        compiler="extJavac"
        deprecation="yes"
-       source="1.6"
-       target="1.6"
+       source="11"
+       target="11"
        >
     </javac>
   </target>

--- a/source-mobile-sim-env.sh
+++ b/source-mobile-sim-env.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# Assumes that the environment variable $MOBILE_SIM_HOME is set to this directory
+
+# Surprisingly tricky! https://stackoverflow.com/a/63072463/474819
+THISDIR=$(realpath $(dirname ${BASH_SOURCE[0]:-$0}))
+
+export MOBILE_SIM_HOME=$THISDIR
 
 ### Setup Environment Variables
 

--- a/source-mobile-sim-env.sh
+++ b/source-mobile-sim-env.sh
@@ -5,6 +5,8 @@ THISDIR=$(realpath $(dirname ${BASH_SOURCE[0]:-$0}))
 
 export MOBILE_SIM_HOME=$THISDIR
 
+echo "\e[93mLoading MobileSim development environment from $MOBILE_SIM_HOME\e[0m"
+
 ### Setup Environment Variables
 
 export CLASSPATH=$CLASSPATH:$MOBILE_SIM_HOME/java/mobilesim.jar


### PR DESCRIPTION
I tested this with Java 17 from Temurin, though I've only conservatively set the source and target values to 11. 1.6 is not supported with newer Javas, but when I tested with 1.8 (zulu), the ant builds would hang until I ctrl-c killed them the first time I ran them, which is not amenable to Dockerization.